### PR TITLE
fix: several bugs

### DIFF
--- a/resource/specs/dev.toml
+++ b/resource/specs/dev.toml
@@ -103,7 +103,7 @@ rfc_0031 = 0
 rfc_0032 = 0
 rfc_0036 = 0
 rfc_0038 = 0
-rfc_tmp1 = 0
+rfc_tmp1 = 1
 
 [pow]
 func = "Dummy"

--- a/resource/specs/staging.toml
+++ b/resource/specs/staging.toml
@@ -101,7 +101,7 @@ rfc_0031 = 0
 rfc_0032 = 0
 rfc_0036 = 0
 rfc_0038 = 0
-rfc_tmp1 = 0
+rfc_tmp1 = 1
 
 [pow]
 func = "Eaglesong"

--- a/spec/src/hardfork.rs
+++ b/spec/src/hardfork.rs
@@ -126,6 +126,12 @@ impl HardForkConfig {
     ///
     /// Enable features which are set to `None` at the user provided epoch (or block).
     pub fn complete_with_default(&self) -> Result<HardForkSwitch, String> {
+        if self.rfc_tmp1.map(|v| v == 0).unwrap_or(false) {
+            let errmsg = "Found the hard fork feature parameter \"rfc_tmp1\" is \
+                in the chain specification file, and its value is 0.
+                But it should NOT be 0 since genesis block doesn't has chain root.";
+            return Err(errmsg.to_string());
+        }
         HardForkSwitch::new_builder()
             .rfc_0028(self.rfc_0028.unwrap_or(EpochNumber::MAX))
             .rfc_0029(self.rfc_0029.unwrap_or(EpochNumber::MAX))


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

- Genesis block doesn't has chain root for all chains, so default value of `MMR_ACTIVATED_BLOCK` should be 1 not 0; and if user set it to be `0`, then ckb should raise an error.

- Two sampled difficulties maybe point to a same block.

  So it shouldn't increase `start_block_number` in the method `get_block_numbers_via_difficulties` even we use it as the result of previous sampled difficulty.

- The `end_block_number` for the method `get_first_block_total_difficulty_is_not_less_than` could NOT be returned.

  So the `end_block_number` should be `difficulty_boundary`, not `difficulty_boundary - 1`.

- A typo when check "the maximum difficulty should be less than the difficulty boundary".